### PR TITLE
Fix cast as in type inference engine

### DIFF
--- a/examples/project_1/models/revenue.sql
+++ b/examples/project_1/models/revenue.sql
@@ -1,5 +1,6 @@
 CREATE VIEW revenue AS
-SELECT product_id, euro
+SELECT CAST(product_id AS VARCHAR) product_id,
+    euro
 FROM product_sales;
 CREATE MATERIALIZED VIEW rev_per_product AS
 SELECT SUM(euro) AS rev,


### PR DESCRIPTION
Cast AS referred to same `expr` value used in parameter erroneously.

Added a test for cast and fixed the problem. 