### PR TITLE
Type check tests

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -217,6 +217,25 @@ fn build_graph(deps: &HashMap<String, Vec<String>>) -> Result<HashMap<&str, Mode
     Ok(graph)
 }
 
+fn find_test_files(tests: Option<Vec<String>>) -> Vec<String> {
+    let mut tests_models = vec![];
+    if let Some(tests) = tests {
+        for dir in tests {
+            for entry in WalkDir::new(dir.to_string()) {
+                let entry = entry.unwrap();
+                if let Some(ext) = entry.path().extension() {
+                    {
+                        if ext == "sql" {
+                            tests_models.push(entry.path().to_str().unwrap().to_string());
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return tests_models;
+}
+
 #[tokio::main]
 pub async fn main() -> Result<(), String> {
     let opt = Opt::from_args();
@@ -274,23 +293,8 @@ pub async fn main() -> Result<(), String> {
                     }
                 }
             }
-            // TODO reuse test code
-            let mut tests_models = vec![];
-            if let Some(tests) = config.project.tests {
-                for dir in tests {
-                    for entry in WalkDir::new(dir.to_string()) {
-                        let entry = entry.unwrap();
-                        if let Some(ext) = entry.path().extension() {
-                            {
-                                if ext == "sql" {
-                                    tests_models.push(entry.path().to_str().unwrap().to_string());
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            let tests = load_tests(&tests_models);
+            let test_models = find_test_files(config.project.tests);
+            let tests = load_tests(&test_models);
 
             for test in tests {
                 types::get_model_type(get_query(&test), ty_env.clone())?;
@@ -338,24 +342,8 @@ pub async fn main() -> Result<(), String> {
             print!("{:?}", arrows);
         }
         Command::Test => {
-            let mut tests_models = vec![];
-            if let Some(tests) = config.project.tests {
-                for dir in tests {
-                    for entry in WalkDir::new(dir.to_string()) {
-                        let entry = entry.unwrap();
-                        if let Some(ext) = entry.path().extension() {
-                            {
-                                if ext == "sql" {
-                                    tests_models.push(entry.path().to_str().unwrap().to_string());
-                                }
-                            }
-                        }
-                    }
-                }
-            } else {
-                println!("No tests defined in powersql.toml");
-            }
-            let tests = load_tests(&tests_models);
+            let test_models = find_test_files(config.project.tests);
+            let tests = load_tests(&test_models);
             let mut executor = execute::PostgresExecutor::new()
                 .await
                 .map_err(|x| format!("Connection error: {}", x))?;

--- a/src/types.rs
+++ b/src/types.rs
@@ -170,9 +170,7 @@ pub fn get_model_type(
                             let ty = expr_type(&expr, &local_type_env, unknown_sources)?;
                             items.push((id.to_string(), ty))
                         }
-                        _ => {
-                            Err("Unnamed expressions not supported")?;
-                        }
+                        _ => {}
                     },
                     _ => {
                         is_open = true;


### PR DESCRIPTION
We should syntax / type check the tests as well.

This allows both to be more sure the tests will not have any errors when running them, as it allows for better refactoring in the SQL models (as we can have more code depending on columns / types to be available.